### PR TITLE
Interpolate AccountId as a string

### DIFF
--- a/provider.yml
+++ b/provider.yml
@@ -58,7 +58,7 @@ Resources:
 
           def update_provider(arn, doc):
             # Need to create the ARN from the name
-            arn = "arn:aws:iam::" + str(${AWS::AccountId}) + ":saml-provider/" + name
+            arn = "arn:aws:iam::${AWS::AccountId}:saml-provider/" + name
             try:
               resp = iam.update_saml_provider(SAMLMetadataDocument=doc, SAMLProviderArn=arn)
               return (True, "SAML provider " + arn + " updated")
@@ -69,7 +69,7 @@ Resources:
             provider_xml = event['ResourceProperties']['Metadata']
             provider_name = event['ResourceProperties']['Name']
             # create a default ARN from the name; will be overwritten if we are creating
-            provider_arn = "arn:aws:iam::" + str(${AWS::AccountId}) + ":saml-provider/" + provider_name
+            provider_arn = "arn:aws:iam::${AWS::AccountId}:saml-provider/" + provider_name
 
             if event['RequestType'] == 'Create':
               res, provider_arn = create_provider(provider_name, provider_xml)


### PR DESCRIPTION
If you AWS AccountId begins with either `08` or `09`, interpolating the ID as a int will cause an invalid token error in python 2.7, since a leading zero indicates an octal number and . To fix this, you can interpolate the AccountId directly into the arn var as a string. 


```
Python 2.7.10 (default, Aug 17 2018, 17:41:52)
>>> id = 064357427001
>>> type(id)
<type 'int'>
>>> id = 095259967903
  File "<stdin>", line 1
    id = 095259967903
                    ^
SyntaxError: invalid token
```