### PR TITLE
removed str function

### DIFF
--- a/provider.yml
+++ b/provider.yml
@@ -58,7 +58,7 @@ Resources:
 
           def update_provider(arn, doc):
             # Need to create the ARN from the name
-            arn = "arn:aws:iam::" + str(${AWS::AccountId}) + ":saml-provider/" + name
+            arn = "arn:aws:iam::${AWS::AccountId}:saml-provider/" + name
             try:
               resp = iam.update_saml_provider(SAMLMetadataDocument=doc, SAMLProviderArn=arn)
               return (True, "SAML provider " + arn + " updated")
@@ -69,7 +69,7 @@ Resources:
             provider_xml = event['ResourceProperties']['Metadata']
             provider_name = event['ResourceProperties']['Name']
             # create a default ARN from the name; will be overwritten if we are creating
-            provider_arn = "arn:aws:iam::" + str(${AWS::AccountId}) + ":saml-provider/" + provider_name
+            provider_arn = "arn:aws:iam::${AWS::AccountId}:saml-provider/" + provider_name
 
             if event['RequestType'] == 'Create':
               res, provider_arn = create_provider(provider_name, provider_xml)


### PR DESCRIPTION
The str function is not needed on the context, and the function would fail when AWS account number starts with a leading zero.