### PR TITLE
Fix bug in update_provider

### DIFF
--- a/provider.yml
+++ b/provider.yml
@@ -57,8 +57,6 @@ Resources:
               return (False, "Cannot delete SAML provider with ARN " + arn + ": " + str(e))
 
           def update_provider(arn, doc):
-            # Need to create the ARN from the name
-            arn = "arn:aws:iam::${AWS::AccountId}:saml-provider/" + name
             try:
               resp = iam.update_saml_provider(SAMLMetadataDocument=doc, SAMLProviderArn=arn)
               return (True, "SAML provider " + arn + " updated")


### PR DESCRIPTION
The ARN gets passed to the function and doesn't have to be constructed again.

Co-authored-by: Mathias Lafeldt <mathias.lafeldt@gmail.com>