### PR TITLE
Add IDP ARN as output for nested stack support

### DIFF
--- a/provider.yml
+++ b/provider.yml
@@ -117,3 +117,8 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: "*"
+
+Outputs:
+  ProviderArn:
+    Description: Arn of the Identity Provider
+    Value: !Ref 'IdentityProvider'


### PR DESCRIPTION
Just a simple addition of an output of the Identity Provider ARN supplied by the custom resource for support in nested stacks.
